### PR TITLE
Use newer version of nvm

### DIFF
--- a/Level_1/1. Setting up dev Environment/README.md
+++ b/Level_1/1. Setting up dev Environment/README.md
@@ -13,7 +13,7 @@ You can use the following instructions to setup your development environment. Op
 You can install NVM on your Mac by running the following command:
 
 ```
-    curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash
+    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
 ```
 
 #### For Ubuntu
@@ -22,7 +22,7 @@ On Ubuntu/WSL you can install NVM by running the following command:
 
 ```
     sudo apt-get install -y curl
-    curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash
+    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
 ```
 
 #### All Users


### PR DESCRIPTION
In Level 1, Setting up dev environment, instructions installs an older version of NVM. However, trying to run `nvm install --lts` on nvm 0.33.11 yields the following.
![image](https://user-images.githubusercontent.com/25143503/156988983-9f3ba165-9677-4ec1-9047-ea9d71f45b24.png)

I've updated the links to fetch the latest nvm as of today and works without issues.
Tested on Ubuntu.
